### PR TITLE
Prevent the clone from hiding behind the table

### DIFF
--- a/js/dataTables.rowReorder.js
+++ b/js/dataTables.rowReorder.js
@@ -215,7 +215,7 @@ RowReorder.prototype = {
 		clone
 			.width( tableWidth )
 			.height( tableHeight )
-			.zIndex( tableZIndex)
+			.zIndex( tableZIndex )
 			.find('tr').children().each( function (i) {
 				this.style.width = sizes[i]+'px';
 			} );

--- a/js/dataTables.rowReorder.js
+++ b/js/dataTables.rowReorder.js
@@ -207,6 +207,7 @@ RowReorder.prototype = {
 		// to reduce reflows
 		var tableWidth = target.outerWidth();
 		var tableHeight = target.outerHeight();
+		var tableZIndex = target.zIndex();
 		var sizes = target.children().map( function () {
 			return $(this).width();
 		} );
@@ -214,6 +215,7 @@ RowReorder.prototype = {
 		clone
 			.width( tableWidth )
 			.height( tableHeight )
+			.zIndex( tableZIndex)
 			.find('tr').children().each( function (i) {
 				this.style.width = sizes[i]+'px';
 			} );


### PR DESCRIPTION
setting the zindex of the clone to match the zindex of the table to prevent it from being drawn behind the table when the table is inside a modal, or otherwise hovers over the page.