### PR TITLE
updating to add reorderOnSort functionality

### DIFF
--- a/js/dataTables.rowReorder.js
+++ b/js/dataTables.rowReorder.js
@@ -285,9 +285,7 @@ $.extend( RowReorder.prototype, {
 		for ( i=0, ien=Nodes.length ; i<ien ; i++ ) {
 
 			var rowData = dt.row( Nodes[i] ).data();
-
-			//ToDo replace with generic function call
-			rowData.feature.properties.TableOrder = i;
+			setDataFn(rowData, i);
 
 			var row = dt.row(Nodes[i]);
 			row.invalidate('data');

--- a/js/dataTables.rowReorder.js
+++ b/js/dataTables.rowReorder.js
@@ -144,7 +144,7 @@ $.extend( RowReorder.prototype, {
 			}
 		} );
 		
-		// check if sorting should reorders data
+		// check if sorting should reorder data
 		// if it should reorder, then it adds listener for sorting, and when data has been 
 		// sorted, it updates data with new row numbers.
 		if (that.c.reorderOnSort) { 

--- a/js/dataTables.rowReorder.js
+++ b/js/dataTables.rowReorder.js
@@ -143,6 +143,15 @@ $.extend( RowReorder.prototype, {
 				return false;
 			}
 		} );
+		
+		// check if sorting should reorders data
+		// if it should reorder, then it adds listener for sorting, and when data has been 
+		// sorted, it updates data with new row numbers.
+		if (that.c.reorderOnSort) { 
+			$( table ).on( 'order.dt', function (e, table, sort) {
+				that._ReNumerate();
+    			});
+		}
 
 		dt.on( 'destroy', function () {
 			table.off( 'mousedown.rowReorder' );
@@ -256,6 +265,34 @@ $.extend( RowReorder.prototype, {
 			left: left
 		} );
 	},
+	
+	/**
+	 * Update the items position based on new order
+	 *
+	 * @private
+	 */
+	_ReNumerate: function ()
+	{
+		var i, ien,
+		dt = this.s.dt;
+
+		// Calculate the difference
+		var Nodes = $.unique(dt.rows().nodes().toArray());
+
+		var getDataFn = this.s.getDataFn;
+		var setDataFn = this.s.setDataFn;
+
+		for ( i=0, ien=Nodes.length ; i<ien ; i++ ) {
+
+			var rowData = dt.row( Nodes[i] ).data();
+
+			//ToDo replace with generic function call
+			rowData.feature.properties.TableOrder = i;
+
+			var row = dt.row(Nodes[i]);
+			row.invalidate('data');
+		}
+	},
 
 
 	/**
@@ -304,6 +341,12 @@ $.extend( RowReorder.prototype, {
 		var that = this;
 		var dt = this.s.dt;
 		var start = this.s.start;
+		
+		//if the table has been reordered on sorting, then this will set the sorting 
+		//to new column order when dragging and dropping rows
+		if (this.c.reorderOnSort) {
+			dt.order([0,'asc']);
+		}
 
 		var offset = target.offset();
 		start.top = this._eventToPage( e, 'Y' );
@@ -547,7 +590,14 @@ RowReorder.defaults = {
 	 *
 	 * @type {Boolean}
 	 */
-	update: true
+	update: true,
+	
+	/**
+	 * Update the sequence on sorting
+	 *
+	 * @type {Boolean}
+	 */
+	reorderOnSort: false
 };
 
 


### PR DESCRIPTION
adds function to reorder the sequence when sorted - see #2 for details.

If the option is true, the sequence reorders on every sort.  If a user then drags a row, the table automatically switches it's sort to the sequence row to allow for a custom order based upon the sort.
