### PR TITLE
post-row-reorder event added.

### DIFF
--- a/docs/event/post-row-reorder.xml
+++ b/docs/event/post-row-reorder.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dt-event library="RowReorder">
+	<name>post-row-reorder</name>
+	<summary>After rows have been reordered by the end user</summary>
+	<since>1.0.0</since>
+
+	<type type="function">
+		<signature>function( e, details, edit )</signature>
+		<parameter type="object" name="e">
+			jQuery event object
+		</parameter>
+		<parameter type="array" name="details">
+			An array of change objects for the row's how have had values effected. Each object contain the following properties:
+
+			* `-type *` `newData` - The new data value for the row (data point defined by `rr-init rowReorder.dataSrc`)
+			* `-type node` `node` - The `-tag tr` element
+			* `-type integer` `newPosition` - New index in the DOM
+			* `-type *` `oldData` - The old data value for the row
+			* `-type integer` `oldPosition` - Old index in the DOM
+		</parameter>
+		<parameter type="object" name="edit">
+			This parameter provides the information required for [Editor](//editor.datatables.net) to perform a multi-row edit:
+
+			* `-type string` `dataSrc` - Data point - typically the field to be edited (defined by `rr-init rowReorder.dataSrc`)
+			* `-type array` `nodes` - The rows to be edited
+			* `-type object` `values` - The new values in a format suitable for `e-api multiSet()`.
+		</parameter>
+		<scope>HTML table element</scope>
+	</type>
+
+	<description>
+		The event data is identical to the `rr-event row-reorder` event. In comparison to the `rr-event row-reorder` event, the event will be triggered after the row is dropped and written to the database.
+
+		The data that has been changed by RowReorder is given in two different forms in the parameters for the event handler callback - one with detailed information about the individual rows, and one with data in a format suitable for [Editor's](//editor.datatables.net) multi-row editing feature.
+
+		Please note that, as with all DataTables emitted events, this event is triggered with the `dt` namespace. As such, to listen for this event, you must also use the `dt` namespace by simply appending `.dt` to your event name, or use the `dt-api on()` method to listen for the event which will automatically append this namespace.
+	</description>
+
+	<example title="Add a class to all changed rows"><![CDATA[
+
+var table = $('#example').DataTable( {
+	rowReorder: true
+} );
+
+table.on( 'post-row-reorder', function ( e, diff, edit ) {
+	for ( var i=0, ien=diff.length ; i<ien ; i++ ) {
+		$(diff[i].node).addClass("reordered");
+	}
+} );
+
+]]></example>
+
+</dt-event>

--- a/docs/event/row-reordered.xml
+++ b/docs/event/row-reordered.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <dt-event library="RowReorder">
-	<name>post-row-reorder</name>
+	<name>row-reordered</name>
 	<summary>After rows have been reordered by the end user</summary>
 	<since>1.0.0</since>
 
@@ -29,7 +29,8 @@
 	</type>
 
 	<description>
-		The event data is identical to the `rr-event row-reorder` event. In comparison to the `rr-event row-reorder` event, the event will be triggered after the row is dropped and written to the database.
+		The event data is identical to the `rr-event row-reorder` event. In comparison to the `rr-event row-reorder` event, the event will be triggered after the row is dropped and after the data is updated. 
+		This event is only triggered if the `rr-init rowReorder.update` option has been enabled (which it is by default).
 
 		The data that has been changed by RowReorder is given in two different forms in the parameters for the event handler callback - one with detailed information about the individual rows, and one with data in a format suitable for [Editor's](//editor.datatables.net) multi-row editing feature.
 
@@ -42,7 +43,7 @@ var table = $('#example').DataTable( {
 	rowReorder: true
 } );
 
-table.on( 'post-row-reorder', function ( e, diff, edit ) {
+table.on( 'row-reordered', function ( e, diff, edit ) {
 	for ( var i=0, ien=diff.length ; i<ien ; i++ ) {
 		$(diff[i].node).addClass("reordered");
 	}

--- a/js/dataTables.rowReorder.js
+++ b/js/dataTables.rowReorder.js
@@ -518,6 +518,13 @@ $.extend( RowReorder.prototype, {
 					}
 				} );
 			}
+			
+			// Trigger post row reorder event
+			this._emitEvent( 'post-row-reorder', [ fullDiff, {
+				dataSrc: dataSrc,
+				nodes:   diffNodes,
+				values:  idDiff
+			} ] );
 
 			dt.draw( false );
 		}

--- a/js/dataTables.rowReorder.js
+++ b/js/dataTables.rowReorder.js
@@ -486,12 +486,15 @@ $.extend( RowReorder.prototype, {
 			}
 		}
 		
-		// Emit event
-		this._emitEvent( 'row-reorder', [ fullDiff, {
+		// Create event args
+		var eventArgs = [ fullDiff, {
 			dataSrc: dataSrc,
 			nodes:   diffNodes,
 			values:  idDiff
-		} ] );
+		} ];
+		
+		// Emit event
+		this._emitEvent( 'row-reorder', eventArgs );
 
 		// Editor interface
 		if ( this.c.editor ) {
@@ -519,12 +522,8 @@ $.extend( RowReorder.prototype, {
 				} );
 			}
 			
-			// Trigger post row reorder event
-			this._emitEvent( 'post-row-reorder', [ fullDiff, {
-				dataSrc: dataSrc,
-				nodes:   diffNodes,
-				values:  idDiff
-			} ] );
+			// Trigger row reordered event
+			this._emitEvent( 'row-reordered', eventArgs );
 
 			dt.draw( false );
 		}


### PR DESCRIPTION
We need to trigger an event after the reorder row is processed and written to the database. So I have added an post-row-reorder event trigger after the update is performed. I also added the api documentation.
I hope you'll include this in future releases.