### PR TITLE
Allow anchor links and other elements to continue working within reorder selector

### DIFF
--- a/js/dataTables.rowReorder.js
+++ b/js/dataTables.rowReorder.js
@@ -180,6 +180,11 @@ $.extend( RowReorder.prototype, {
 				return;
 			}
 
+			// Ignore excluded children of the selector
+			if ( $(e.target).is(that.c.excludedChildren) ) {
+				return true;
+			}
+
 			var tr = $(this).closest('tr');
 			var row = dt.row( tr );
 
@@ -734,7 +739,15 @@ RowReorder.defaults = {
 	 *
 	 * @type {Boolean}
 	 */
-	update: true
+	update: true,
+
+	/**
+	 * Selector for children of the drag handle selector that mouseDown events
+	 * will be passed through to and drag will not activate
+	 *
+	 * @type {String}
+	 */
+	excludedChildren: 'a'
 };
 
 


### PR DESCRIPTION
Added excludedChildren option to allow setting children of the selector that won't activate the drag and will maintain their default functionality.

If you have a link within the reorder selector, this will allow that link to keep working.