### PR TITLE
Fix typo in ternary expression

### DIFF
--- a/js/dataTables.rowReorder.js
+++ b/js/dataTables.rowReorder.js
@@ -240,7 +240,7 @@ $.extend( RowReorder.prototype, {
 		} );
 
 		var middles = $.map( tops, function ( top, i ) {
-			return tops.length < i-1 ?
+			return i < tops.length-1 ?
 				(top + tops[i+1]) / 2 :
 				(top + top + $( dt.row( ':last-child' ).node() ).outerHeight() ) / 2;
 		} );


### PR DESCRIPTION
I was reading through the code, because I'm experiencing some issues with this extension, when I stumbled upon this ternary expression. The length of an array will never be lower than an index so the falsy expression will always be used. This results in calculating the middle of each row based on the height of the last row.

P.S. I'm happy to include this under the MIT license!