### PR TITLE
Fix row being dragged above first group header

### DIFF
--- a/js/dataTables.rowReorder.js
+++ b/js/dataTables.rowReorder.js
@@ -434,7 +434,6 @@ $.extend( RowReorder.prototype, {
 		var middles = this.s.middles;
 		var insertPoint = null;
 		var dt = this.s.dt;
-		var body = dt.table().body();
 
 		// Determine where the row should be inserted based on the mouse
 		// position
@@ -451,18 +450,13 @@ $.extend( RowReorder.prototype, {
 
 		// Perform the DOM shuffle if it has changed from last time
 		if ( this.s.lastInsert === null || this.s.lastInsert !== insertPoint ) {
-			if ( insertPoint === 0 ) {
-				this.dom.target.prependTo( body );
+			var nodes = $.unique( dt.rows( { page: 'current' } ).nodes().toArray() );
+
+			if ( insertPoint > this.s.lastInsert ) {
+				this.dom.target.insertAfter( nodes[ insertPoint-1 ] );
 			}
 			else {
-				var nodes = $.unique( dt.rows( { page: 'current' } ).nodes().toArray() );
-
-				if ( insertPoint > this.s.lastInsert ) {
-					this.dom.target.insertAfter( nodes[ insertPoint-1 ] );
-				}
-				else {
-					this.dom.target.insertBefore( nodes[ insertPoint ] );
-				}
+				this.dom.target.insertBefore( nodes[ insertPoint ] );
 			}
 
 			this._cachePositions();


### PR DESCRIPTION
When using this extension in combination with the RowGroup extension, the old behaviour resulted in the dragged row being inserted above the first header. While this is not a functional bug, I do think this is a visual bug as it looks like you drag it out of the group.

N.B. This fixes issue 1 I described in https://datatables.net/forums/discussion/comment/171255/#Comment_171255.

**Reproduction**
1. Visit http://live.datatables.net/tavikoma/1/edit?html,js,console,output;
2. Drag a row in group "Edinburgh" to the top of the group;
3. See it is placed above the group header until you drop it.

P.S. I'm happy to include this under the MIT license!