### PR TITLE
Fix incorrect middle calculation of the last row in a group

### DIFF
--- a/js/dataTables.rowReorder.js
+++ b/js/dataTables.rowReorder.js
@@ -235,14 +235,10 @@ $.extend( RowReorder.prototype, {
 		// not what DataTables thinks it is, since we have been altering the
 		// order
 		var nodes = $.unique( dt.rows( { page: 'current' } ).nodes().toArray() );
-		var tops = $.map( nodes, function ( node, i ) {
-			return $(node).position().top - headerHeight;
-		} );
+		var middles = $.map( nodes, function ( node, i ) {
+			var top = $(node).position().top - headerHeight;
 
-		var middles = $.map( tops, function ( top, i ) {
-			return i < tops.length-1 ?
-				(top + tops[i+1]) / 2 :
-				(top + top + $( dt.row( ':last-child' ).node() ).outerHeight() ) / 2;
+			return (top + top + $(node).outerHeight() ) / 2;
 		} );
 
 		this.s.middles = middles;


### PR DESCRIPTION
When using this extension in combination with the RowGroup extension, the old behaviour resulted in an incorrect middle calculation of the last row in a group because the top of the next row is offset with the height of the group header. While in most cases this is not a huge problem, it starts to get weird when the group header gets taller and the user has to drag the row halfway the group header before it is moved to the last position of its group.

N.B. This does introduce a slight performance degradation in favour of accuracy as it is getting the outerHeight of each row instead of only the last one. However, I do think this is justified as it might only be an issue with huge unpaged tables. Besides, the performance should be equal prior to my earlier fix in #23 as it already calculated the outerHeight of the last row for every row!

**Reproduction**
1. Visit http://live.datatables.net/tavikoma/1/edit?html,js,console,output;
2. Drag the second-last row (Dai Rios) in group "Edinburgh" below the last row in that same group (Gavin Joyce);
3. See you have to drag it all the way past the last row before it is moved instead of the middle of that row like all other rows.

P.S. I'm happy to include this under the MIT license!