### PR TITLE
Add support for multi row reorder

### DIFF
--- a/examples/initialisation/multiRowReorder.xml
+++ b/examples/initialisation/multiRowReorder.xml
@@ -18,7 +18,7 @@ $('#example').DataTable({
 <![CDATA[
 let table = new DataTable('#example', {
     select: true,
-	rowReorder: true,
+    rowReorder: true,
     selector: 'tr',
     select: 'os',
 });

--- a/examples/initialisation/multiRowReorder.xml
+++ b/examples/initialisation/multiRowReorder.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dt-example table-type="sequence" table-class="display" order="10">
+<title lib="RowReorder">Multi row reorder</title>
+
+<css lib="datatables rowreorder select" />
+<js lib="jquery datatables rowreorder select">
+<![CDATA[
+$('#example').DataTable({
+    select: true,
+    rowReorder: true,
+    selector: 'tr',
+    select: 'os',
+});
+]]>
+</js>
+
+<js-vanilla>
+<![CDATA[
+let table = new DataTable('#example', {
+    select: true,
+	rowReorder: true,
+    selector: 'tr',
+    select: 'os',
+});
+]]>
+</js-vanilla>
+
+<info><![CDATA[
+The following example demonstrates how the RowReorder extension can work together with Select, if it's in use, in order to make multiple row reordering possible.
+]]></info>
+
+</dt-example>

--- a/js/dataTables.rowReorder.js
+++ b/js/dataTables.rowReorder.js
@@ -235,7 +235,9 @@ $.extend(RowReorder.prototype, {
 		// Match the table and column widths - read all sizes before setting
 		// to reduce reflows
 		var tableWidth = target.outerWidth();
-		var tableHeight = target.outerHeight();
+		var tableHeight = target.toArray()
+			.map(function (el) { return $(el).outerHeight(); })
+			.reduce(function (accum, val) { return accum + val; });
 		var scrollBody = $($(this.s.dt.table().node()).parent());
 		var scrollWidth = scrollBody.width();
 		var scrollLeft = scrollBody.scrollLeft();
@@ -361,6 +363,26 @@ $.extend(RowReorder.prototype, {
 		start.offsetTop = offset.top;
 		start.offsetLeft = offset.left;
 		start.nodes = $.unique(dt.rows({ page: 'current' }).nodes().toArray());
+
+		var targetRow = dt.row($(target));
+		// Only execute this code if the Select extension is being used
+		if (typeof targetRow.select !== "undefined" && typeof targetRow.selected !== "undefined") {
+			// If we are dragging a row that is not selected, but there are other selected rows, we'll deselect
+			// them first, and then select the current target
+			var selectedRows = [];
+			$.merge(selectedRows, target.siblings('.selected'));
+			if (selectedRows.length > 0 && !targetRow.selected()) {
+				// We might want to remove the previous selection, unless the user is adding more keys by
+				// pressing keyboard combinations, in that case, let Select do its job
+				if (e.shiftKey || e.metaKey || e.ctrlKey) {
+					return;
+				}
+
+				dt.rows().deselect();
+			}
+
+			$.merge(target, target.siblings('.selected'));
+		}
 
 		this._cachePositions();
 		this._clone(target);
@@ -518,7 +540,7 @@ $.extend(RowReorder.prototype, {
 				dataSrc: dataSrc,
 				nodes: diffNodes,
 				values: idDiff,
-				triggerRow: dt.row(this.dom.target),
+				triggerRow: dt.rows(this.dom.target),
 				originalEvent: e
 			}
 		];
@@ -602,12 +624,23 @@ $.extend(RowReorder.prototype, {
 			var nodes = $.unique(dt.rows({ page: 'current' }).nodes().toArray());
 			var insertPlacement = '';
 
+			var nodeInsertPoint = nodes[insertPoint];
 			if (insertPoint > this.s.lastInsert) {
-				this.dom.target.insertAfter(nodes[insertPoint - 1]);
+				var buffer = this.dom.target.length-1;
+
+				if (!nodes[insertPoint + buffer]) {
+					this.dom.target.appendTo(dt.table().body());
+				} else if ($(nodeInsertPoint).hasClass('dt-rowReorder-moving')) {
+					this.dom.target.insertBefore(nodes[insertPoint + buffer]);
+				} else {
+					this.dom.target.insertAfter(nodes[insertPoint + buffer - 1]);
+				}
 				insertPlacement = 'after';
 			}
 			else {
-				this.dom.target.insertBefore(nodes[insertPoint]);
+				if (!$(nodeInsertPoint).hasClass('dt-rowReorder-moving')) {
+					this.dom.target.insertBefore(nodeInsertPoint);
+				}
 				insertPlacement = 'before';
 			}
 


### PR DESCRIPTION
This PR is a rewrite of PR #17, but without making Select a hard dependency for RowReorder. It also adds the example page and has been cleaned up, to make the change as small as possible.

It can be merged under the MIT license.